### PR TITLE
use host 127.0.0.1 in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, Final
 from aiohttp import ClientWebSocketResponse
 from aiohttp.test_utils import TestClient
 
-API_HOST: Final[str] = "localhost"
+API_HOST: Final[str] = "127.0.0.1"
 API_PORT: Final[int] = 9123
 REQUEST_ID: Final[str] = "test"
 TOKEN: Final[str] = "abc123"


### PR DESCRIPTION
Otherwise they can fail with

    pytest_socket.SocketConnectBlockedError: A test tried to use socket.socket.connect() with host "::1" (allowed: "127.0.0.1").