### PR TITLE
Drop incremental from runtime dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp>=3.8.5;python_version<'3.12'
 aiohttp>=3.9.0b0;python_version>='3.12'
-incremental>=24.7.2
 packaging>=24.0
 systembridgemodels>=4.2.4


### PR DESCRIPTION
Is incremental needed at runtime?

We are introducing new checks in Home Assistant https://github.com/home-assistant/core/pull/145381

It seems that incremental relies on setuptools - but is incremental actually needed at runtime? or only at build time?
https://github.com/timmo001/system-bridge-connector/blob/640895c56353ebae98e49897d249be546d41c7cb/requirements.txt#L3